### PR TITLE
Rename gem name

### DIFF
--- a/red-remote-input.gemspec
+++ b/red-remote-input.gemspec
@@ -7,7 +7,7 @@ end
 require_relative "lib/datastock/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "red-datastock"
+  spec.name = "red-remote-input"
   spec.version = DataStock::VERSION
   spec.homepage = "https://github.com/red-data-tools/red-datastock"
   spec.authors = ["Kouhei Sutou"]


### PR DESCRIPTION
We decide to rename this gem so that the name could indicate appropreate behavior.
We expect this gem will behave like IO-related gems, so the name includes 'input.'
This gem includes input of remote data but doesn't include any output. Thus the name includes only 'input', not 'IO.'