### PR TITLE
Add missing require

### DIFF
--- a/lib/remote_input/downloader.rb
+++ b/lib/remote_input/downloader.rb
@@ -7,6 +7,7 @@ require "net/http"
 require "pathname"
 
 require_relative "error"
+require_relative "version"
 
 module RemoteInput
   class Downloader


### PR DESCRIPTION
To fix the following error:

```console
$ rake
/Users/zzz/.rbenv/versions/3.4.2/bin/ruby test/run-test.rb
Loaded suite test
Started
F
========================================================================
Failure: test: too many redirection(DownloaderTest::#download)
/Users/zzz/src/github.com/red-data-tools/red-remote-input/test/test-downloader.rb:61:in 'block (2 levels) in <class:DownloaderTest>'
     58:         raise RemoteInput::Downloader::TooManyRedirects, "too many redirections: #{last_url}"
     59:       end
     60:
  => 61:       assert_raise(RemoteInput::Downloader::TooManyRedirects.new(expected_message)) do
     62:         downloader.download(output_path)
     63:       end
     64:     end

<RemoteInput::Downloader::TooManyRedirects(<too many redirections: https://example.com/file .. https://example.com/last_redirection>)> expected but was
<NameError(<uninitialized constant RemoteInput::Downloader::VERSION>)
(snip)
```