### PR TITLE
ci: update Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
-          - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         runs-on:
           - macos-latest
           - ubuntu-latest


### PR DESCRIPTION
Ruby now only maintains only 3.2, 3.3 and 3.4.